### PR TITLE
Set last modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ Sets the cache scope (public/private) of requests that are not tokenized
 
 Sets the cache scope (public/private) of requests that are tokenized (query / cookie)
 
+#### akamai_token_last_modified
+* **syntax**: `akamai_token_last_modified time`
+* **default**: `Sun, 19 Nov 2000 08:52:00 GMT`
+* **context**: `http`, `server`, `location`
+
+Sets the value of the last-modified header of requests that are not tokenized.
+An empty string leaves the value of last-modified unaltered, while the string "now" sets the header to the server current time.
+
+#### akamai_token_token_last_modified
+* **syntax**: `akamai_token_token_last_modified time`
+* **default**: `now`
+* **context**: `http`, `server`, `location`
+
+Sets the value of the last-modified header of requests that are tokenized (query / cookie)
+An empty string leaves the value of last-modified unaltered, while the string "now" sets the header to the server current time.
+
 ## Copyright & License
 
 All code in this project is released under the [AGPLv3 license](http://www.gnu.org/licenses/agpl-3.0.html) unless a different license for a particular library is specified in the applicable library path. 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ starts with one of the defined prefixes will return a token
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Sets the expiration time of requests that are not tokenized 
+Sets the expiration time of responses that are not tokenized 
 (determines the values of the Cache-Control and Expires HTTP headers)
 
 #### akamai_token_cookie_token_expires_time
@@ -79,7 +79,7 @@ Sets the expiration time of requests that are not tokenized
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Sets the expiration time of requests that are tokenized with a cookie token 
+Sets the expiration time of responses that are tokenized with a cookie token 
 (determines the values of the Cache-Control and Expires HTTP headers)
 
 #### akamai_token_query_token_expires_time
@@ -87,7 +87,7 @@ Sets the expiration time of requests that are tokenized with a cookie token
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Sets the expiration time of requests that are tokenized with a query string token 
+Sets the expiration time of responses that are tokenized with a query string token 
 (determines the values of the Cache-Control and Expires HTTP headers)
 
 #### akamai_token_cache_scope
@@ -95,21 +95,21 @@ Sets the expiration time of requests that are tokenized with a query string toke
 * **default**: `public`
 * **context**: `http`, `server`, `location`
 
-Sets the cache scope (public/private) of requests that are not tokenized
+Sets the cache scope (public/private) of responses that are not tokenized
 
 #### akamai_token_token_cache_scope
 * **syntax**: `akamai_token_token_cache_scope scope`
 * **default**: `private`
 * **context**: `http`, `server`, `location`
 
-Sets the cache scope (public/private) of requests that are tokenized (query / cookie)
+Sets the cache scope (public/private) of responses that are tokenized (query / cookie)
 
 #### akamai_token_last_modified
 * **syntax**: `akamai_token_last_modified time`
 * **default**: `Sun, 19 Nov 2000 08:52:00 GMT`
 * **context**: `http`, `server`, `location`
 
-Sets the value of the last-modified header of requests that are not tokenized.
+Sets the value of the last-modified header of responses that are not tokenized.
 An empty string leaves the value of last-modified unaltered, while the string "now" sets the header to the server current time.
 
 #### akamai_token_token_last_modified
@@ -117,7 +117,7 @@ An empty string leaves the value of last-modified unaltered, while the string "n
 * **default**: `now`
 * **context**: `http`, `server`, `location`
 
-Sets the value of the last-modified header of requests that are tokenized (query / cookie)
+Sets the value of the last-modified header of responses that are tokenized (query / cookie)
 An empty string leaves the value of last-modified unaltered, while the string "now" sets the header to the server current time.
 
 ## Copyright & License

--- a/ngx_http_akamai_token_filter_module.c
+++ b/ngx_http_akamai_token_filter_module.c
@@ -544,9 +544,9 @@ static ngx_int_t
 ngx_http_akamai_token_call_next_filter(
 	ngx_http_request_t *r, 
 	time_t expires, 
-	time_t last_modified, 
-	ngx_str_t* last_modified_str, 
-	ngx_str_t* cache_scope)
+	ngx_str_t* cache_scope,
+	time_t last_modified,
+	ngx_str_t* last_modified_str)
 {
 	ngx_table_elt_t *h;
 	ngx_int_t rc;
@@ -629,9 +629,9 @@ ngx_http_akamai_token_header_filter(ngx_http_request_t *r)
         return ngx_http_akamai_token_call_next_filter(
 			r, 
 			conf->expires_time, 
+			&conf->cache_scope,
 			conf->last_modified_time, 
-			&conf->last_modified, 
-			&conf->cache_scope);
+			&conf->last_modified);
     }
 
 	// check the file name
@@ -663,9 +663,9 @@ ngx_http_akamai_token_header_filter(ngx_http_request_t *r)
 			return ngx_http_akamai_token_call_next_filter(
 				r, 
 				conf->expires_time, 
+				&conf->cache_scope, 
 				conf->last_modified_time,
-				&conf->last_modified,
-				&conf->cache_scope);
+				&conf->last_modified);
 		}
 	}
 
@@ -717,9 +717,9 @@ ngx_http_akamai_token_header_filter(ngx_http_request_t *r)
 		return ngx_http_akamai_token_call_next_filter(
 			r, 
 			conf->query_token_expires_time, 
+			&conf->token_cache_scope,
 			conf->token_last_modified_time,
-			&conf->token_last_modified,
-			&conf->token_cache_scope);
+			&conf->token_last_modified);
 	}
 	else
 	{
@@ -736,9 +736,9 @@ ngx_http_akamai_token_header_filter(ngx_http_request_t *r)
 		return ngx_http_akamai_token_call_next_filter(
 			r, 
 			conf->cookie_token_expires_time, 
+			&conf->token_cache_scope,
 			conf->token_last_modified_time,
-			&conf->token_last_modified,
-			&conf->token_cache_scope);
+			&conf->token_last_modified);
 	}
 }
 


### PR DESCRIPTION
by default, tokenized responses set the value of last-modified to the server time, while responses that are not tokenized set it to a fixed time stamp (Sun, 19 Nov 2000 08:52:00 GMT)